### PR TITLE
fix separator on Windows platform; rename module name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following example will show the minimal usage with mix-gulp-qiniu
 
 ```
 var gulp = require('gulp'),
-    qiniuCDN = require('gulp-qiniu-cdn');
+    qiniuCDN = require('mix-gulp-qiniu');
 
 gulp.task('qiniu', function () {
     return gulp.src(['app/**/*.*'])

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var through = require('through2');
 var qiniu = require('qiniu');
 
 // consts
+const PATH_SEPARATOR = require('path').sep;
 const PLUGIN_NAME = 'mix-gulp-qiniu';
 
 function uploadFile(localFile, key, uptoken, cb) {
@@ -47,7 +48,7 @@ function gulpQiniuCdn(conf) {
   // creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, cb) {
     var path = file.history[0];
-    var fileName = path.split("/").pop();
+    var fileName = path.split(PATH_SEPARATOR).pop();
 
     var extra = new qiniu.io.PutExtra(params, mimeType, crc32, checkCrc);
 


### PR DESCRIPTION
Windows上传的文件路径是“\”,用path.sep可以兼容不同平台，或者每次都先normalize一下路径再处理。
版本号没有改 🍻 